### PR TITLE
Add minimal Next.js todo app

### DIFF
--- a/app/api/todos/route.ts
+++ b/app/api/todos/route.ts
@@ -1,0 +1,43 @@
+type Todo = { id: string; title: string; completed: boolean };
+
+let todos: Todo[] = [];
+
+const validateTitle = (title: unknown): title is string =>
+  typeof title === 'string' && title.trim().length > 0 && title.length <= 100;
+
+export async function GET() {
+  return Response.json(todos);
+}
+
+export async function POST(req: Request) {
+  const { title } = await req.json();
+  if (!validateTitle(title)) {
+    return new Response('Invalid title', { status: 400 });
+  }
+  const todo: Todo = { id: crypto.randomUUID(), title: title.trim(), completed: false };
+  todos.push(todo);
+  return Response.json(todo, { status: 201 });
+}
+
+export async function PATCH(req: Request) {
+  const { id, title, completed } = await req.json();
+  const todo = todos.find((t) => t.id === id);
+  if (!todo) return new Response('Not found', { status: 404 });
+
+  if (title !== undefined) {
+    if (!validateTitle(title)) return new Response('Invalid title', { status: 400 });
+    todo.title = title.trim();
+  }
+  if (completed !== undefined) {
+    todo.completed = !!completed;
+  }
+  return Response.json(todo);
+}
+
+export async function DELETE(req: Request) {
+  const { id } = await req.json();
+  const index = todos.findIndex((t) => t.id === id);
+  if (index === -1) return new Response('Not found', { status: 404 });
+  const [removed] = todos.splice(index, 1);
+  return Response.json(removed);
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from 'next';
+import './globals.css';
+
+export const metadata: Metadata = {
+  title: 'Todo App',
+  description: 'Simple Next.js Todo App',
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body className="max-w-xl mx-auto p-4">{children}</body>
+    </html>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,99 @@
+'use client';
+
+import { useEffect, useState, FormEvent } from 'react';
+
+type Todo = { id: string; title: string; completed: boolean };
+
+export default function Home() {
+  const [todos, setTodos] = useState<Todo[]>([]);
+  const [title, setTitle] = useState('');
+
+  const loadTodos = async () => {
+    const res = await fetch('/api/todos');
+    if (res.ok) {
+      setTodos(await res.json());
+    }
+  };
+
+  useEffect(() => {
+    loadTodos();
+  }, []);
+
+  const addTodo = async (e: FormEvent) => {
+    e.preventDefault();
+    const res = await fetch('/api/todos', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title }),
+    });
+    if (res.ok) {
+      const todo: Todo = await res.json();
+      setTodos((t) => [...t, todo]);
+      setTitle('');
+    }
+  };
+
+  const toggleTodo = async (id: string) => {
+    const target = todos.find((t) => t.id === id);
+    if (!target) return;
+    const res = await fetch('/api/todos', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id, completed: !target.completed }),
+    });
+    if (res.ok) {
+      const updated: Todo = await res.json();
+      setTodos((t) => t.map((todo) => (todo.id === id ? updated : todo)));
+    }
+  };
+
+  const deleteTodo = async (id: string) => {
+    const res = await fetch('/api/todos', {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id }),
+    });
+    if (res.ok) {
+      setTodos((t) => t.filter((todo) => todo.id !== id));
+    }
+  };
+
+  return (
+    <main>
+      <form onSubmit={addTodo} className="flex gap-2 mb-4">
+        <input
+          className="border p-2 flex-1"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          placeholder="Add todo"
+          required
+          maxLength={100}
+        />
+        <button className="bg-blue-500 text-white px-4" type="submit">
+          Add
+        </button>
+      </form>
+      <ul className="space-y-2">
+        {todos.map((todo) => (
+          <li key={todo.id} className="flex items-center gap-2">
+            <input
+              type="checkbox"
+              checked={todo.completed}
+              onChange={() => toggleTodo(todo.id)}
+            />
+            <span className={todo.completed ? 'line-through flex-1' : 'flex-1'}>
+              {todo.title}
+            </span>
+            <button
+              className="text-red-500"
+              type="button"
+              onClick={() => deleteTodo(todo.id)}
+            >
+              Delete
+            </button>
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,0 +1,5 @@
+import type { NextConfig } from 'next';
+
+const nextConfig: NextConfig = {};
+
+export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "digeon_hands_on",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "^15.5.2",
+    "react": "^19.1.1",
+    "react-dom": "^19.1.1"
+  },
+  "devDependencies": {
+    "typescript": "^5.9.2",
+    "@types/react": "^19.1.12",
+    "@types/node": "^24.3.1",
+    "@types/react-dom": "^19.1.9",
+    "tailwindcss": "^3.4.17",
+    "postcss": "^8.5.6",
+    "autoprefixer": "^10.4.21"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,11 @@
+import type { Config } from 'tailwindcss';
+
+const config: Config = {
+  content: ['./app/**/*.{ts,tsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};
+
+export default config;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,35 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
+  },
+  "include": [
+    "**/*.ts",
+    "**/*.tsx",
+    "next-env.d.ts",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}


### PR DESCRIPTION
## Summary
- scaffold minimal Next.js App Router project with TypeScript and Tailwind
- implement in-memory Todo CRUD API with title validation
- add client todo page with add/list/toggle/delete UI

## Testing
- `npm run dev`


------
https://chatgpt.com/codex/tasks/task_e_68bbcf7fce648332aa70d6e29a8962e1